### PR TITLE
feat: 동영상 플레이어 썸네일 적용

### DIFF
--- a/src/components/videoPlayer/component.tsx
+++ b/src/components/videoPlayer/component.tsx
@@ -8,11 +8,13 @@ import { debounce } from '@/utils/debounce';
 interface VideoPlayerProps {
   source: string;
   title: string;
+  thumbnail?: string;
 }
 
 export default function VideoPlayer({
   source,
   title,
+  thumbnail,
 }: VideoPlayerProps) {
   const containerRef = useRef<HTMLElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -89,6 +91,7 @@ export default function VideoPlayer({
         onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
         onProgress={handleBufferProgress}
         controls={false}
+        poster={thumbnail}
         playsInline
       >
         <source src={source} />

--- a/src/fetcher/videoFetcher/component.tsx
+++ b/src/fetcher/videoFetcher/component.tsx
@@ -26,6 +26,7 @@ export default function VideoFetcher({ videoId }: VideoFetcherProps) {
         <VideoPlayer
           source={`${process.env.NEXT_PUBLIC_CDN_VIDEO_URL}/${data.id}`}
           title={data.title}
+          thumbnail={`${process.env.NEXT_PUBLIC_CDN_THUMBNAIL_URL}/${data.id}`}
         />
       </div>
       <div className={styles.contentSection}>


### PR DESCRIPTION
## 개요
동영상 플레이어에 썸네일을 적용합니다.

## 구현 내용
- 동영상 카드 썸네일

![동영상 카드 썸네일](https://github.com/user-attachments/assets/6bf68f7e-30c5-4b93-8ede-41f7cf3b027c)

- 동영상 플레이어 썸네일

![동영상 플레이어 썸네일](https://github.com/user-attachments/assets/1a1892e9-6a6e-4f9b-ab10-5484af1d8c94)

`<video>` 요소의 `poster` 속성에 썸네일 URL을 적용하였습니다.
