### PR TITLE
동영상 플레이어 수정

### DIFF
--- a/src/components/videoPlayer/component.tsx
+++ b/src/components/videoPlayer/component.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import styles from './style.module.css';
 import VideoPlayerControlPanel from '../videoPlayerControlPanel/component';
 import { debounce } from '@/utils/debounce';
@@ -25,30 +25,9 @@ export default function VideoPlayer({
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [duration, setDuration] = useState<number>(0);
   const [bufferedProgress, setBufferedProgress] = useState<number>(0);
-  const [isSeeking, setIsSeeking] = useState<boolean>(false);
-  const [isPausedBeforeSeek, setIsPausedBeforeSeek] = useState<boolean>(true);
   const [isBuffering, setIsBuffering] = useState<boolean>(false);
 
   const debouncedHidePanelRef = useRef(debounce(() => setIsPanelShown(false), 3000));
-
-  useEffect(() => {
-    if (!isSeeking) {
-      setIsPausedBeforeSeek(!isPlaying);
-    }
-  }, [isSeeking, isPlaying]);
-
-  useEffect(() => {
-    if (!videoRef.current) {
-      return;
-    }
-
-    if (isSeeking) {
-      videoRef.current.pause();
-    }
-    else if (!isPausedBeforeSeek) {
-      videoRef.current.play();
-    }
-  }, [isSeeking, isPausedBeforeSeek]);
 
   const handleShowPanel = () => {
     if (!isPanelShown) {
@@ -97,6 +76,7 @@ export default function VideoPlayer({
         onWaiting={() => setIsBuffering(true)}
         onCanPlay={() => setIsBuffering(false)}
         playsInline
+        preload="metadata"
       >
         <source src={source} />
       </video>
@@ -111,7 +91,6 @@ export default function VideoPlayer({
           currentTime={currentTime}
           duration={duration}
           setCurrentTime={setCurrentTime}
-          setIsSeeking={setIsSeeking}
           bufferedProgress={bufferedProgress}
         />
       </div>

--- a/src/components/videoPlayer/component.tsx
+++ b/src/components/videoPlayer/component.tsx
@@ -90,6 +90,7 @@ export default function VideoPlayer({
           isPlaying={isPlaying}
           currentTime={currentTime}
           duration={duration}
+          setIsPlaying={setIsPlaying}
           setCurrentTime={setCurrentTime}
           bufferedProgress={bufferedProgress}
         />

--- a/src/components/videoPlayerControlPanel/component.tsx
+++ b/src/components/videoPlayerControlPanel/component.tsx
@@ -16,6 +16,7 @@ interface VideoPlayerControlPanelProps {
   isPlaying: boolean;
   currentTime: number;
   duration: number;
+  setIsPlaying: Dispatch<SetStateAction<boolean>>;
   setCurrentTime: Dispatch<SetStateAction<number>>;
   bufferedProgress: number;
 }
@@ -26,6 +27,7 @@ export default function VideoPlayerControlPanel({
   isPlaying,
   currentTime,
   duration,
+  setIsPlaying,
   setCurrentTime,
   bufferedProgress,
 }: VideoPlayerControlPanelProps) {
@@ -62,10 +64,8 @@ export default function VideoPlayerControlPanel({
 
       playPromise.then(() => {
         playPromiseRef.current = null;
-      }).catch((error) => {
-        if (error?.name !== 'AbortError') {
-          console.error('동영상 재생에 실패했습니다: ', error);
-        }
+      }).catch(() => {
+        setIsPlaying(false);
         playPromiseRef.current = null;
       });
     }

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,4 +1,4 @@
-export function debounce<T extends (...args: unknown[]) => void>(
+export function debounce<T extends (...args: Parameters<T>) => void>(
   callbackFn: T,
   delay: number,
 ) {

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,16 @@
+export function throttle<T extends (...args: Parameters<T>) => void>(
+  callbackFn: T,
+  delay: number,
+) {
+  let timer: ReturnType<typeof setTimeout> | null;
+
+  return (...args: Parameters<T>) => {
+    if (!timer) {
+      callbackFn(...args);
+
+      timer = setTimeout(() => {
+        timer = null;
+      }, delay);
+    }
+  };
+}


### PR DESCRIPTION
## 개요
동영상 플레이어의 버그를 수정하고 내부 로직을 더 직관적으로 변경하였습니다.

## 세부 구현 내용
### `play()` 요청 비동기 처리
`<video>` 요소에서 `play()` 요청 시 즉시 재생되는 것이 아니라 `Promise`를 반환합니다.
따라서 `Promise`를 `ref`에 저장하여 아직 `play()` 요청이 `pending` 상태일 경우 중복 요청을 방지하였습니다.
`Promise`가 `rejected`되었을 시 `isPlaying` 상태를 `false`로 강제 업데이트하여 UI의 잘못된 동작을 방지하였습니다.
`Promise`가 `fulfilled` 또는 `rejected` 되면 `ref`를 `null`로 초기화해 새로운 요청이 실행될 수 있도록 구현하였습니다.

### 동영상 구간 탐색 `throttle` 적용
재생 바의 `change` 이벤트가 너무 빈번하게 발생할 경우 상태 업데이트로 인해 성능 저하가 야기될 수 있으므로 `throttle`을 적용하여 상태 업데이트의 과도한 업데이트를 방지하였습니다.

### `debounce()` 제네릭 수정
`debounce()` 사용 시 타입 추론이 가능하도록 수정하였습니다.