### PR TITLE
CD 파이프라인 제거

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -34,25 +34,3 @@ jobs:
             NEXT_PUBLIC_CDN_CHANNELIMAGE_URL=${{ secrets.NEXT_PUBLIC_CDN_CHANNELIMAGE_URL }}
             NEXT_PUBLIC_CDN_VIDEO_URL=${{ secrets.NEXT_PUBLIC_CDN_VIDEO_URL }}
             NEXT_PUBLIC_CDN_THUMBNAIL_URL=${{ secrets.NEXT_PUBLIC_CDN_THUMBNAIL_URL }}
-      -
-        name: Add SSH key to known hosts
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
-      -
-        name: Deploy to EC2
-        env:
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-        run: |
-          echo "$EC2_SSH_KEY" > opqo_aws_action.pem
-          chmod 400 opqo_aws_action.pem
-
-          ssh -i opqo_aws_action.pem ubuntu@${{ secrets.EC2_HOST }} << EOF
-          
-            cd /home/ubuntu
-            docker compose down
-            docker compose pull
-            docker compose up -d
-          EOF
-
-          rm -f ec2_key.pem


### PR DESCRIPTION
## 개요
다음과 같은 어려움이 있어 AWS의 S3 및 CodeDeploy, Jenkins 등 다른 방법을 적용시키기 전 까지 CD 파이프라인을 제거합니다.

1. EC2에 SSH 접속을 위해서는 **인바운드 규칙을 통해 허용할 IP를 설정**하여야 합니다.
2. Github Actions 실행 시 **runner의 IP는 고정적이지 않습니다.**
3. IP를 **인증되지 않은 3rd party actions를 사용하지 않고** 가져오는 데 어려움이 있습니다.
4. IP를 가져오는 데 성공하고, SSH 접속을 위해 EC2 인스턴스의 인바운드 규칙을 업데이트 하는데 성공한다 하더라도, **인바운드 규칙 업데이트와 SSH 접속은 순차적으로 이루어지지 않기 때문**에 Action이 실패할 가능성이 있습니다.