### PR TITLE
내 스튜디오 구현

### DIFF
--- a/src/apis/channel.ts
+++ b/src/apis/channel.ts
@@ -68,3 +68,18 @@ export async function getMyChannelList({ accessToken }: GetMyChannelListParams) 
     { headers: { Authorization: accessTokenToBearer(accessToken) } },
   );
 }
+
+interface GetMyChannelInfoParams extends AuthenticationParams { }
+interface GetMyChannelInfoResponse {
+  id: string;
+  name: string;
+  description: string;
+  createdDate: string;
+}
+
+export async function getMyChannelInfo({ accessToken }: GetMyChannelInfoParams) {
+  return fetchInstance.get<GetMyChannelInfoResponse>(
+    '/channels/me',
+    { headers: { Authorization: accessTokenToBearer(accessToken) } },
+  );
+}

--- a/src/apis/video.ts
+++ b/src/apis/video.ts
@@ -171,3 +171,25 @@ export async function getMyVideoList({ accessToken }: GetMyVideoListParams) {
     { headers: { Authorization: accessTokenToBearer(accessToken) } },
   );
 }
+
+interface GetMyVideoMetadataParams extends AuthenticationParams { id: string }
+interface GetMyVideoMetadataResponse {
+  id: string;
+  width: number;
+  height: number;
+  duration: number;
+  size: number;
+  extension: string;
+  status: string;
+  createdDate: string;
+}
+
+export async function getMyVideoMetadata({
+  accessToken,
+  id,
+}: GetMyVideoMetadataParams) {
+  return fetchInstance.get<GetMyVideoMetadataResponse>(
+    `/videos/${id}`,
+    { headers: { Authorization: accessTokenToBearer(accessToken) } },
+  );
+}

--- a/src/apis/video.ts
+++ b/src/apis/video.ts
@@ -157,3 +157,17 @@ interface GetVideoListResponse {
 export async function getVideoList({ category }: GetVideoListParams) {
   return fetchInstance.get<GetVideoListResponse[]>(`/contents?view=${category}`);
 }
+
+interface GetMyVideoListParams extends AuthenticationParams { }
+interface GetMyVideoListResponse {
+  id: string;
+  status: string;
+  createdDate: string;
+}
+
+export async function getMyVideoList({ accessToken }: GetMyVideoListParams) {
+  return fetchInstance.get<GetMyVideoListResponse[]>(
+    '/channels/me/videos',
+    { headers: { Authorization: accessTokenToBearer(accessToken) } },
+  );
+}

--- a/src/app/(main)/layout.module.css
+++ b/src/app/(main)/layout.module.css
@@ -1,0 +1,6 @@
+.content {
+  position: relative;
+  margin-top: 3.75rem;
+  height: calc(100% - 3.75rem);
+  overflow-y: auto;
+}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,10 +1,13 @@
 import Header from '@/components/header/component';
+import styles from './layout.module.css';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Header />
-      {children}
+      <div className={styles.content}>
+        {children}
+      </div>
     </>
   );
 }

--- a/src/app/(main)/studio/contents/[videoId]/page.module.css
+++ b/src/app/(main)/studio/contents/[videoId]/page.module.css
@@ -1,0 +1,5 @@
+.title {
+  padding: 1.5rem 2rem;
+  font-weight: 700;
+  font-size: 1.75rem;
+}

--- a/src/app/(main)/studio/contents/[videoId]/page.tsx
+++ b/src/app/(main)/studio/contents/[videoId]/page.tsx
@@ -1,0 +1,15 @@
+import styles from './page.module.css';
+import MyVideoInfoFetcher from '@/fetcher/myVIdeoInfoFetcher/component';
+
+interface MyVideoInfoPageProps { params: Promise<{ videoId: string }> }
+
+export default async function MyVideoInfoPage({ params }: MyVideoInfoPageProps) {
+  const { videoId } = await params;
+
+  return (
+    <main>
+      <h1 className={styles.title}>내 콘텐츠 정보</h1>
+      <MyVideoInfoFetcher id={videoId} />
+    </main>
+  );
+}

--- a/src/app/(main)/studio/contents/page.module.css
+++ b/src/app/(main)/studio/contents/page.module.css
@@ -1,0 +1,5 @@
+.title {
+  padding: 1.5rem 2rem;
+  font-weight: 700;
+  font-size: 1.75rem;
+}

--- a/src/app/(main)/studio/contents/page.tsx
+++ b/src/app/(main)/studio/contents/page.tsx
@@ -1,0 +1,11 @@
+import StudioContentsFetcher from '@/fetcher/studioContentsFetcher/component';
+import styles from './page.module.css';
+
+export default function StudioContentsPage() {
+  return (
+    <main>
+      <h1 className={styles.title}>내 콘텐츠 목록</h1>
+      <StudioContentsFetcher />
+    </main>
+  );
+}

--- a/src/app/(main)/studio/info/page.module.css
+++ b/src/app/(main)/studio/info/page.module.css
@@ -1,0 +1,7 @@
+.title {
+  width: 100%;
+  font-size: 1.75rem;
+  padding: 2rem;
+  font-weight: 700;
+  text-align: center;
+}

--- a/src/app/(main)/studio/info/page.tsx
+++ b/src/app/(main)/studio/info/page.tsx
@@ -1,0 +1,11 @@
+import styles from './page.module.css';
+import StudioInfoFetcher from '@/fetcher/studioInfoFetcher/component';
+
+export default function StudioInfoPage() {
+  return (
+    <main>
+      <h1 className={styles.title}>내 채널 정보</h1>
+      <StudioInfoFetcher />
+    </main>
+  );
+}

--- a/src/app/(main)/studio/layout.module.css
+++ b/src/app/(main)/studio/layout.module.css
@@ -1,0 +1,33 @@
+.navigationBar {
+  position: fixed;
+  width: 17.5rem;
+  border-right: 1px solid var(--lightgray-shadow);
+  height: 100%;
+}
+
+.title {
+  padding: 1rem;
+  font-size: 1.125rem;
+  font-weight: 400;
+}
+
+.menuList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu {
+  display: block;
+  padding: 0.75rem 0 0.75rem 1rem;
+  font-size: 1.5rem;
+}
+
+.current {
+  font-weight: 700;
+  border-right: 0.5rem solid var(--blue);
+}
+
+.content {
+  margin-left: 17.5rem;
+}

--- a/src/app/(main)/studio/layout.tsx
+++ b/src/app/(main)/studio/layout.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import styles from './layout.module.css';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const PATH_INFO = '/studio/info';
+const PATH_CONTENTS = '/studio/contents';
+
+type CurrentPath = typeof PATH_INFO | typeof PATH_CONTENTS | null;
+
+export default function StudioLayout({ children }: { children: React.ReactNode }) {
+  const [currentPath, setCurrentPath] = useState<CurrentPath>(null);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname.startsWith(PATH_INFO)) {
+      setCurrentPath(PATH_INFO);
+    }
+    else if (pathname.startsWith(PATH_CONTENTS)) {
+      setCurrentPath(PATH_CONTENTS);
+    }
+  }, [pathname]);
+
+  return (
+    <>
+      <nav className={styles.navigationBar}>
+        <h3 className={styles.title}>내 스튜디오</h3>
+        <ul className={styles.menuList}>
+          <li>
+            <Link
+              className={`${styles.menu}${currentPath === PATH_INFO ? ` ${styles.current}` : ''}`}
+              href={PATH_INFO}
+              aria-current={currentPath === PATH_INFO ? 'page' : undefined}
+            >
+              정보
+            </Link>
+          </li>
+          <li>
+            <Link
+              className={`${styles.menu}${currentPath === PATH_CONTENTS ? ` ${styles.current}` : ''}`}
+              href={PATH_CONTENTS}
+              aria-current={currentPath === PATH_CONTENTS ? 'page' : undefined}
+            >
+              콘텐츠
+            </Link>
+          </li>
+        </ul>
+      </nav>
+      <div className={styles.content}>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,13 +13,14 @@
 
 html,
 body {
+  height: 100%;
   min-height: 100vh;
   max-width: 100vw;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 body {
-  color: var(--text);
+  color: var(--black);
   background: var(--white);
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/components/authTopBar/component.tsx
+++ b/src/components/authTopBar/component.tsx
@@ -89,6 +89,14 @@ export default function AuthTopBar({ auth }: AuthTopBarProps) {
                   내 채널
                 </Link>
               </li>
+              <li>
+                <Link
+                  href="/studio/info"
+                  className={styles.menu}
+                >
+                  내 스튜디오
+                </Link>
+              </li>
             </ul>
             <div className={styles.signout}>
               <CustomButton

--- a/src/components/header/style.module.css
+++ b/src/components/header/style.module.css
@@ -1,9 +1,13 @@
 .container {
-  position: relative;
+  position: fixed;
+  z-index: 9999;
+  width: 100%;
+  background-color: var(--white);
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 0 2rem;
+  border-bottom: 1px solid var(--lightgray-shadow);
 }
 
 .logo {

--- a/src/components/myVideoInfo/component.tsx
+++ b/src/components/myVideoInfo/component.tsx
@@ -1,0 +1,76 @@
+import { numberToTime } from '@/utils/time';
+import Thumbnail from '../thumbnail/component';
+import styles from './style.module.css';
+import { numberToFileSize } from '@/utils/convert';
+import { formatDateTimeString } from '@/utils/date';
+
+interface MyVideoInfoProps {
+  id: string;
+  width: number;
+  height: number;
+  duration: number;
+  size: number;
+  extension: string;
+  status: string;
+  createdDate: string;
+  title: string;
+  description: string;
+}
+
+export default function MyVideoInfo({
+  id,
+  width,
+  height,
+  duration,
+  size,
+  extension,
+  status,
+  createdDate,
+  title,
+  description,
+}: MyVideoInfoProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.thumbnail}>
+        <Thumbnail
+          videoId={id}
+          videoTitle={title}
+        />
+      </div>
+      <div className={styles.info}>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>동영상 제목</h2>
+          <p className={styles.title}>{title}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>해상도</h2>
+          <p>{`${width} X ${height}`}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>동영상 길이</h2>
+          <p>{numberToTime(duration)}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>동영상 크기</h2>
+          <p>{numberToFileSize(size)}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>확장자</h2>
+          <p>{extension}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>상태</h2>
+          <p>{status}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>생성한 날짜</h2>
+          <p>{formatDateTimeString(createdDate)}</p>
+        </section>
+        <section className={styles.category}>
+          <h2 className={styles.categoryTitle}>동영상 설명</h2>
+          <p>{description}</p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/myVideoInfo/style.module.css
+++ b/src/components/myVideoInfo/style.module.css
@@ -6,7 +6,8 @@
   width: 24rem;
   aspect-ratio: 16/9;
   background: var(--black);
-  border-radius: 1rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
 }
 
 .info {

--- a/src/components/myVideoInfo/style.module.css
+++ b/src/components/myVideoInfo/style.module.css
@@ -1,0 +1,34 @@
+.container {
+  padding: 0 2rem 2rem;
+}
+
+.thumbnail {
+  width: 24rem;
+  aspect-ratio: 16/9;
+  background: var(--black);
+  border-radius: 1rem;
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.title {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.category {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.categoryTitle {
+  font-weight: 400;
+  font-size: 0.875rem;
+  color: var(--gray);
+}

--- a/src/components/studioContentCard/component.tsx
+++ b/src/components/studioContentCard/component.tsx
@@ -1,0 +1,33 @@
+import { formatDateString } from '@/utils/date';
+import Thumbnail from '../thumbnail/component';
+import styles from './style.module.css';
+
+interface StudioContentCardProps {
+  id: string;
+  title: string;
+  createdDate: string;
+  status: string;
+}
+
+export default function StudioContentCard({
+  id,
+  title,
+  createdDate,
+  status,
+}: StudioContentCardProps) {
+  return (
+    <article className={styles.container}>
+      <div className={styles.thumbnail}>
+        <Thumbnail
+          videoId={id}
+          videoTitle={title}
+        />
+      </div>
+      <h2 className={styles.title}>{title}</h2>
+      <div className={styles.info}>
+        <div className={styles.createdDate}>{formatDateString(createdDate)}</div>
+        <div className={styles.status}>{status}</div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/studioContentCard/component.tsx
+++ b/src/components/studioContentCard/component.tsx
@@ -1,6 +1,7 @@
 import { formatDateString } from '@/utils/date';
 import Thumbnail from '../thumbnail/component';
 import styles from './style.module.css';
+import Link from 'next/link';
 
 interface StudioContentCardProps {
   id: string;
@@ -23,7 +24,9 @@ export default function StudioContentCard({
           videoTitle={title}
         />
       </div>
-      <h2 className={styles.title}>{title}</h2>
+      <Link href={`/studio/contents/${id}`}>
+        <h2 className={styles.title}>{title}</h2>
+      </Link>
       <div className={styles.info}>
         <div className={styles.createdDate}>{formatDateString(createdDate)}</div>
         <div className={styles.status}>{status}</div>

--- a/src/components/studioContentCard/style.module.css
+++ b/src/components/studioContentCard/style.module.css
@@ -1,0 +1,28 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.thumbnail {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16/9;
+  background-color: var(--black);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.title {
+  margin-top: 0.25rem;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.info {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  font-size: 0.875rem;
+}

--- a/src/components/studioInfo/component.tsx
+++ b/src/components/studioInfo/component.tsx
@@ -1,0 +1,40 @@
+import { formatDateString } from '@/utils/date';
+import ChannelImage from '../channelImage/component';
+import styles from './style.module.css';
+
+interface StudioInfoProps {
+  id: string;
+  name: string;
+  description: string;
+  createdDate: string;
+}
+
+export default function StudioInfo({
+  id,
+  name,
+  description,
+  createdDate,
+}: StudioInfoProps) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.channelImage}>
+        <ChannelImage
+          channelId={id}
+          channelName={name}
+        />
+      </div>
+      <section className={styles.category}>
+        <h2 className={styles.categoryTitle}>채널 이름</h2>
+        <p className={styles.name}>{name}</p>
+      </section>
+      <section className={styles.category}>
+        <h2 className={styles.categoryTitle}>채널 설명</h2>
+        <p className={styles.categoryContent}>{description}</p>
+      </section>
+      <section className={styles.category}>
+        <h2 className={styles.categoryTitle}>채널 개설일</h2>
+        <p className={styles.categoryContent}>{formatDateString(createdDate)}</p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/studioInfo/style.module.css
+++ b/src/components/studioInfo/style.module.css
@@ -1,0 +1,34 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-top: 1.5rem;
+  align-items: center;
+}
+
+.channelImage {
+  width: 8rem;
+  height: 8rem;
+}
+
+.category {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.categoryTitle {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--gray);
+}
+
+.name {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.categoryContent {
+  font-size: 1.25rem;
+}

--- a/src/components/thumbnail/component.tsx
+++ b/src/components/thumbnail/component.tsx
@@ -3,18 +3,15 @@
 import Image from 'next/image';
 import styles from './style.module.css';
 import { useState } from 'react';
-import { numberToTime } from '@/utils/time';
 
 interface ThumbnailProps {
   videoId: string;
   videoTitle: string;
-  videoDuration: number;
 }
 
 export default function Thumbnail({
   videoId,
   videoTitle,
-  videoDuration,
 }: ThumbnailProps) {
   const [src, setSrc] = useState<string>(process.env.NEXT_PUBLIC_CDN_THUMBNAIL_URL
     ? `${process.env.NEXT_PUBLIC_CDN_THUMBNAIL_URL}/${videoId}`
@@ -34,7 +31,6 @@ export default function Thumbnail({
         sizes="640px"
         onError={handleError}
       />
-      <div className={styles.videoDuration}>{numberToTime(videoDuration)}</div>
     </div>
   );
 }

--- a/src/components/thumbnail/style.module.css
+++ b/src/components/thumbnail/style.module.css
@@ -7,15 +7,3 @@
 .thumbnail {
   object-fit: contain;
 }
-
-.videoDuration {
-  position: absolute;
-  right: 0.75rem;
-  bottom: 0.75rem;
-  padding: 0.25rem;
-  background-color: var(--black);
-  color: var(--white);
-  border-radius: 0.25rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-}

--- a/src/components/videoCard/component.tsx
+++ b/src/components/videoCard/component.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import ChannelImage from '../channelImage/component';
 import Thumbnail from '../thumbnail/component';
 import { formatDateString } from '@/utils/date';
+import { numberToTime } from '@/utils/time';
 
 interface VideoCardProps {
   videoId: string;
@@ -32,8 +33,8 @@ export default function VideoCard({
           <Thumbnail
             videoId={videoId}
             videoTitle={videoTitle}
-            videoDuration={videoDuration}
           />
+          <div className={styles.videoDuration}>{numberToTime(videoDuration)}</div>
         </div>
       </Link>
       <div className={styles.videoCardInfo}>

--- a/src/components/videoCard/style.module.css
+++ b/src/components/videoCard/style.module.css
@@ -15,6 +15,18 @@
   overflow: hidden;
 }
 
+.videoDuration {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  padding: 0.25rem;
+  background-color: var(--black);
+  color: var(--white);
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
 .videoCardInfo {
   display: flex;
   flex-direction: row;

--- a/src/fetcher/myVIdeoInfoFetcher/component.tsx
+++ b/src/fetcher/myVIdeoInfoFetcher/component.tsx
@@ -1,0 +1,34 @@
+import { getAccessTokenCookie } from '@/serverActions/token';
+import { fetchHandlerWithServerComponent } from '@/utils/handler';
+import { getMyVideoMetadata, getVideoInfo } from '@/apis/video';
+import MyVideoInfo from '@/components/myVideoInfo/component';
+
+interface MyVideoInfoFetcherProps { id: string }
+
+export default async function MyVideoInfoFetcher({ id }: MyVideoInfoFetcherProps) {
+  const accessToken = (await getAccessTokenCookie()) ?? null;
+  const { data: videoMetadata } = await fetchHandlerWithServerComponent(() => getMyVideoMetadata({
+    accessToken,
+    id,
+  }));
+  const { data: videoData } = await fetchHandlerWithServerComponent(() => getVideoInfo({ videoId: id }));
+
+  if (!videoMetadata || !videoData) {
+    return <div>동영상 정보를 불러오지 못했습니다.</div>;
+  }
+
+  return (
+    <MyVideoInfo
+      id={id}
+      width={videoMetadata.width}
+      height={videoMetadata.height}
+      duration={videoMetadata.duration}
+      size={videoMetadata.size}
+      extension={videoMetadata.extension}
+      status={videoMetadata.status}
+      createdDate={videoMetadata.createdDate}
+      title={videoData.title}
+      description={videoData.description}
+    />
+  );
+}

--- a/src/fetcher/studioContentCardFetcher/component.tsx
+++ b/src/fetcher/studioContentCardFetcher/component.tsx
@@ -1,0 +1,30 @@
+import { fetchHandlerWithServerComponent } from '@/utils/handler';
+import { getVideoInfo } from '@/apis/video';
+import StudioContentCard from '@/components/studioContentCard/component';
+
+interface StudioContentCardFetcherProps {
+  id: string;
+  status: string;
+  createdDate: string;
+}
+
+export default async function StudioContentCardFetcher({
+  id,
+  status,
+  createdDate,
+}: StudioContentCardFetcherProps) {
+  const { data } = await fetchHandlerWithServerComponent(() => getVideoInfo({ videoId: id }));
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <StudioContentCard
+      id={id}
+      status={status}
+      createdDate={createdDate}
+      title={data.title}
+    />
+  );
+}

--- a/src/fetcher/studioContentsFetcher/component.tsx
+++ b/src/fetcher/studioContentsFetcher/component.tsx
@@ -1,0 +1,37 @@
+import { getAccessTokenCookie } from '@/serverActions/token';
+import styles from './style.module.css';
+import { fetchHandlerWithServerComponent } from '@/utils/handler';
+import { getMyVideoList } from '@/apis/video';
+import StudioContentCardFetcher from '../studioContentCardFetcher/component';
+
+export default async function StudioContentsFetcher() {
+  const accessToken = (await getAccessTokenCookie()) ?? null;
+  const { data } = await fetchHandlerWithServerComponent(() => getMyVideoList({ accessToken }));
+
+  if (!data) {
+    return <div className={styles.error}>동영상 목록을 불러오지 못했습니다.</div>;
+  }
+
+  return (
+    <ul className={styles.videoList}>
+      {data.length > 0
+        ? data.map(({
+          id,
+          status,
+          createdDate,
+        }) => (
+          <li
+            className={styles.videoCard}
+            key={id}
+          >
+            <StudioContentCardFetcher
+              id={id}
+              status={status}
+              createdDate={createdDate}
+            />
+          </li>
+        ))
+        : <div className={styles.error}>업로드 한 동영상이 없습니다.</div>}
+    </ul>
+  );
+}

--- a/src/fetcher/studioContentsFetcher/style.module.css
+++ b/src/fetcher/studioContentsFetcher/style.module.css
@@ -1,0 +1,47 @@
+@media screen and (width < 36rem) {
+  .videoCard {
+    --videocard-per-row: 1;
+  }
+}
+
+@media screen and (36rem <= width < 50rem) {
+  .videoCard {
+    --videocard-per-row: 2;
+  }
+}
+
+@media screen and (50rem <= width < 73.5rem) {
+  .videoCard {
+    --videocard-per-row: 3;
+  }
+}
+
+@media screen and (73.5rem <= width < 97rem) {
+  .videoCard {
+    --videocard-per-row: 4;
+  }
+}
+
+@media screen and (97rem <= width) {
+  .videoCard {
+    --videocard-per-row: 5;
+  }
+}
+
+.videoList {
+  --videolist-gap: 1rem;
+  --videolist-horizontal-padding: 1rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding: 1rem var(--videolist-horizontal-padding);
+  gap: var(--videolist-gap);
+}
+
+.videoCard {
+  width: calc((100% - ((var(--videocard-per-row) - 1) * var(--videolist-gap))) / var(--videocard-per-row));
+}
+
+.error {
+  margin: 1.5rem 2rem;
+}

--- a/src/fetcher/studioInfoFetcher/component.tsx
+++ b/src/fetcher/studioInfoFetcher/component.tsx
@@ -1,0 +1,23 @@
+import styles from './style.module.css';
+import { getMyChannelInfo } from '@/apis/channel';
+import StudioInfo from '@/components/studioInfo/component';
+import { getAccessTokenCookie } from '@/serverActions/token';
+import { fetchHandlerWithServerComponent } from '@/utils/handler';
+
+export default async function StudioInfoFetcher() {
+  const accessToken = (await getAccessTokenCookie()) ?? null;
+  const { data } = await fetchHandlerWithServerComponent(() => getMyChannelInfo({ accessToken }));
+
+  if (!data) {
+    return <div className={styles.error}>스튜디오 정보를 불러오지 못했습니다.</div>;
+  }
+
+  return (
+    <StudioInfo
+      id={data.id}
+      name={data.name}
+      description={data.description}
+      createdDate={data.createdDate}
+    />
+  );
+}

--- a/src/fetcher/studioInfoFetcher/style.module.css
+++ b/src/fetcher/studioInfoFetcher/style.module.css
@@ -1,0 +1,4 @@
+.error {
+  margin: 1.5rem 2rem;
+  text-align: center;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,7 +20,8 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  if (request.nextUrl.pathname.startsWith('/uploadVideo')) { // 채널 권한 필요
+  if (request.nextUrl.pathname.startsWith('/uploadVideo')
+    || request.nextUrl.pathname.startsWith('/studio')) { // 채널 권한 필요
     const auth = getAuthority(request);
 
     if (!auth) {
@@ -41,6 +42,7 @@ export const config = {
     '/selectChannel',
     '/createChannel',
     '/uploadVideo',
+    '/studio/:path*',
   ],
 };
 

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,0 +1,21 @@
+function toFixedTrim(num: number, digits: number) {
+  return parseFloat(num.toFixed(digits)).toString();
+}
+
+export function numberToFileSize(byte: number) {
+  if (byte < 1024) {
+    return byte === 1 ? `${byte} Byte` : `${byte} Bytes`;
+  }
+
+  if (byte < 1024 * 1024) {
+    return `${toFixedTrim(byte / 1024, 2)} KB`;
+  }
+
+  if (byte < 1024 * 1024 * 1024) {
+    return `${toFixedTrim(byte / (1024 * 1024), 2)} MB`;
+  }
+
+  if (byte < 1024 * 1024 * 1024 * 1024) {
+    return `${toFixedTrim(byte / (1024 * 1024 * 1024), 2)} TB`;
+  }
+}

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -14,9 +14,11 @@ export async function generateVideoHash(blobData: Blob) {
   const buffer = await blobData.arrayBuffer();
   const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
   const hashArray = new Uint8Array(hashBuffer);
-  const base64Hash = btoa(String.fromCharCode(...hashArray));
+  const base16Hash = Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 
-  return base64Hash;
+  return base16Hash;
 }
 
 export async function generateVideoChunkList(videoData: Blob, totalChunkCount: number) {


### PR DESCRIPTION
## 개요
내 채널 정보, 내 콘텐츠 목록 등 소유한 채널의 다양한 정보를 조회할 수 있는 내 스튜디오 페이지를 구현하였습니다.

## 세부 구현 내용
- **내 채널 정보 페이지 구현**

채널 정보를 조회할 수 있는 페이지를 구현하였습니다.

- **내 콘텐츠 목록 / 내 콘텐츠 정보 페이지 구현**

내가 업로드한 동영상 목록 및 해당 동영상의 해상도, 동영상 길이, 크기, 확장자 등 세부 정보를 조회할 수 있는 페이지를 구현하였습니다.

> **내 콘텐츠 정보 페이지**

<img width="706" alt="내 콘텐츠 정보 페이지" src="https://github.com/user-attachments/assets/9aab1423-8e06-4d50-b980-f2b5c4dfe877" />

## 기타 수정 내용
- **동영상 해시 인코딩 방식 변경**

해시 문자열 길이가 64여야 한다는 요구사항을 반영하기 위해 인코딩 방식을 Base64(결과값의 길이가 44)에서 Base16(결과값의 길이가 64)으로 변경하였습니다.
