### PR TITLE
클라이언트와 서버 간 시간대 차이 문제 해결

### DIFF
--- a/src/app/(main)/history/modules/components/watchHistoryList.tsx
+++ b/src/app/(main)/history/modules/components/watchHistoryList.tsx
@@ -7,7 +7,7 @@ import { WatchHistoryListByDate } from '../utils/type';
 import { useFetch } from '@/hooks/useFetch';
 import { useToast } from '@/hooks/useToast';
 import { deleteWatchHistory } from '../apis/deleteWatchHistory';
-import { formatDateString } from '@/utils/dateFormat';
+import Date from '@/components/common/date';
 
 const DELETE_WATCH_HISTORY_SUCCEEDED = '시청 기록을 삭제했습니다.';
 const DELETE_WATCH_HISTORY_FAILED = '시청 기록 삭제에 실패했습니다.';
@@ -73,7 +73,12 @@ export default function WatchHistoryList({ data }: WatchHistoryListProps) {
             watchHistories,
           }, dateIndex) => (
             <li key={watchedDate}>
-              <div className={watchHistoryListStyle.date}>{formatDateString(watchedDate)}</div>
+              <div className={watchHistoryListStyle.date}>
+                <Date
+                  dateStr={watchedDate}
+                  type="date"
+                />
+              </div>
               <ul className={watchHistoryListStyle.list}>
                 {watchHistories.map((watchHistory) => (
                   <li key={watchHistory.video.id}>

--- a/src/app/(main)/studio/contents/[videoId]/modules/components/myVideoInfo.tsx
+++ b/src/app/(main)/studio/contents/[videoId]/modules/components/myVideoInfo.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { numberToFileSize, numberToTime } from '@/utils/convert';
-import { formatDateTimeString } from '@/utils/dateFormat';
 import Thumbnail from '@/components/video/thumbnail';
 import { myVideoInfoStyle } from '../styles/myVideoInfoStyle.css';
 import { studioInfoSectionStyle } from '@/app/(main)/studio/modules/styles/studioInfoSectionStyle.css';
@@ -18,6 +17,7 @@ import { useFetch } from '@/hooks/useFetch';
 import { useToast } from '@/hooks/useToast';
 import { updateMyVideoInfo } from '../apis/updateMyVideoInfo';
 import { deleteMyVideo } from '../apis/deleteMyVideo';
+import Date from '@/components/common/date';
 
 interface MyVideoInfoProps {
   id: string;
@@ -184,7 +184,10 @@ export default function MyVideoInfo({
         {isUploaded ? '업로드 완료' : '업로드 중'}
       </StudioInfoSection>
       <StudioInfoSection title="생성한 날짜">
-        {formatDateTimeString(createdDate)}
+        <Date
+          dateStr={createdDate}
+          type="time"
+        />
       </StudioInfoSection>
       {isEditing
         ? (

--- a/src/app/(main)/studio/contents/modules/components/studioContentCard.tsx
+++ b/src/app/(main)/studio/contents/modules/components/studioContentCard.tsx
@@ -1,8 +1,8 @@
-import { formatDateString } from '@/utils/dateFormat';
 import Link from 'next/link';
 import Thumbnail from '@/components/video/thumbnail';
 import { studioContentCardStyle } from '../styles/studioContentCardStyle.css';
 import { videoCardStyle } from '@/styles/video/videoCardStyle.css';
+import Date from '@/components/common/date';
 
 interface StudioContentCardProps {
   id: string;
@@ -29,7 +29,12 @@ export default function StudioContentCard({
         <h2 className={videoCardStyle.title}>{title}</h2>
       </Link>
       <div className={studioContentCardStyle.info}>
-        <div>{formatDateString(createdDate)}</div>
+        <div>
+          <Date
+            dateStr={createdDate}
+            type="date"
+          />
+        </div>
         <div>{isUploaded ? '업로드 완료' : '업로드 중'}</div>
       </div>
     </article>

--- a/src/app/(main)/studio/info/modules/components/studioInfo.tsx
+++ b/src/app/(main)/studio/info/modules/components/studioInfo.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { formatDateString } from '@/utils/dateFormat';
 import ChannelImage from '@/components/channel/channelImage';
 import { studioInfoStyle } from '../styles/studioInfoStyle.css';
 import { useForm } from 'react-hook-form';
@@ -25,6 +24,7 @@ import Input from '@/components/common/input';
 import Textarea from '@/components/common/textarea';
 import { deleteChannel } from '../apis/deleteChannel';
 import { deleteAccessTokenCookie } from '@/serverActions/token';
+import Date from '@/components/common/date';
 
 interface StudioInfoProps {
   email: string;
@@ -185,7 +185,10 @@ export default function StudioInfo({
           </StudioInfoSection>
         )}
       <StudioInfoSection title="채널 개설일">
-        {formatDateString(createdDate)}
+        <Date
+          dateStr={createdDate}
+          type="date"
+        />
       </StudioInfoSection>
       <div className={studioInfoStyle.button}>
         {isEditing

--- a/src/app/(main)/video/[videoId]/modules/components/videoInfo.tsx
+++ b/src/app/(main)/video/[videoId]/modules/components/videoInfo.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
-import { formatDateTimeString } from '@/utils/dateFormat';
 import ChannelImage from '@/components/channel/channelImage';
 import { videoInfoStyle } from '../styles/videoInfoStyle.css';
+import Date from '@/components/common/date';
 
 interface VideoInfoProps {
   title: string;
@@ -40,7 +40,12 @@ export default function VideoInfo({
         </Link>
       </div>
       <div className={videoInfoStyle.description}>
-        <div>{formatDateTimeString(createdDate)}</div>
+        <div>
+          <Date
+            dateStr={createdDate}
+            type="time"
+          />
+        </div>
         <div>{description}</div>
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import '@/styles/globals.css';
 import ToastProvider from '@/contexts/toast';
 import TokenProvider from '@/contexts/token';
 import { getAccessTokenCookie } from '@/serverActions/token';
+import DateTimeFormatProvider from './modules/components/DateTimeFormatProvider';
 
 export const metadata: Metadata = {
   title: {
@@ -35,7 +36,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
   const accessToken = await getAccessTokenCookie();
 
   return (
-    <html lang="ko">
+    <DateTimeFormatProvider>
       <body className={`${myFont.className}`}>
         <ToastProvider>
           <TokenProvider token={accessToken ?? null}>
@@ -43,6 +44,6 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
           </TokenProvider>
         </ToastProvider>
       </body>
-    </html>
+    </DateTimeFormatProvider>
   );
 }

--- a/src/app/modules/components/DateTimeFormatProvider.tsx
+++ b/src/app/modules/components/DateTimeFormatProvider.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { getLocale, getTimeZone } from '../utils/format';
+import { atom } from 'jotai';
+import { useDateTimeFormat } from '@/hooks/useDateTimeFormat';
+
+const localeAtom = atom<string | undefined>(undefined);
+const timeZoneAtom = atom<string | undefined>(undefined);
+
+export const dateTimeFormatAtoms = {
+  localeAtom,
+  timeZoneAtom,
+};
+
+interface DateTimeFormatProviderProps { children: ReactNode }
+
+export default function DateTimeFormatProvider({ children }: DateTimeFormatProviderProps) {
+  const {
+    locale,
+    setLocale,
+    timeZone,
+    setTimeZone,
+  } = useDateTimeFormat();
+
+  useEffect(() => {
+    if (!locale) {
+      setLocale(getLocale());
+    }
+    if (!timeZone) {
+      setTimeZone(getTimeZone);
+    }
+  }, [locale, timeZone, setLocale, setTimeZone]);
+
+  return (
+    <html lang={locale}>
+      {children}
+    </html>
+  );
+}

--- a/src/app/modules/components/DateTimeFormatProvider.tsx
+++ b/src/app/modules/components/DateTimeFormatProvider.tsx
@@ -28,7 +28,7 @@ export default function DateTimeFormatProvider({ children }: DateTimeFormatProvi
       setLocale(getLocale());
     }
     if (!timeZone) {
-      setTimeZone(getTimeZone);
+      setTimeZone(getTimeZone());
     }
   }, [locale, timeZone, setLocale, setTimeZone]);
 

--- a/src/app/modules/utils/format.ts
+++ b/src/app/modules/utils/format.ts
@@ -1,0 +1,7 @@
+export function getLocale() {
+  return new Intl.DateTimeFormat().resolvedOptions().locale;
+}
+
+export function getTimeZone() {
+  return new Intl.DateTimeFormat().resolvedOptions().timeZone;
+}

--- a/src/components/common/date.tsx
+++ b/src/components/common/date.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useDateTimeFormat } from '@/hooks/useDateTimeFormat';
+import { formatDateString, formatDateTimeString } from '@/utils/dateFormat';
+import { useEffect, useState } from 'react';
+
+interface DateProps {
+  dateStr: string;
+  type: 'date' | 'time';
+}
+
+export default function Date({
+  dateStr,
+  type,
+}: DateProps) {
+  const {
+    locale,
+    timeZone,
+  } = useDateTimeFormat();
+
+  const [formattedStr, setFormattedStr] = useState(dateStr);
+
+  useEffect(() => {
+    if (type === 'date') {
+      setFormattedStr(formatDateString(dateStr, {
+        locale,
+        timeZone,
+      }));
+    }
+    else {
+      setFormattedStr(formatDateTimeString(dateStr, {
+        locale,
+        timeZone,
+      }));
+    }
+  }, [dateStr, locale, timeZone, type]);
+
+  return (
+    <>
+      {formattedStr}
+    </>
+  );
+}

--- a/src/components/video/videoCard.tsx
+++ b/src/components/video/videoCard.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import Thumbnail from './thumbnail';
-import { formatDateString } from '@/utils/dateFormat';
 import ChannelImage from '@/components/channel/channelImage';
 import { videoCardStyle } from '@/styles/video/videoCardStyle.css';
+import Date from '../common/date';
 
 interface VideoCardProps {
   videoId: string;
@@ -67,7 +67,12 @@ export default function VideoCard({
               </Link>
             )
             : null}
-          <div>{formatDateString(createdDate)}</div>
+          <div>
+            <Date
+              dateStr={createdDate}
+              type="date"
+            />
+          </div>
         </div>
       </div>
     </article>

--- a/src/hooks/useDateTimeFormat.ts
+++ b/src/hooks/useDateTimeFormat.ts
@@ -1,0 +1,14 @@
+import { dateTimeFormatAtoms } from '@/app/modules/components/DateTimeFormatProvider';
+import { useAtom } from 'jotai';
+
+export function useDateTimeFormat() {
+  const [locale, setLocale] = useAtom(dateTimeFormatAtoms.localeAtom);
+  const [timeZone, setTimeZone] = useAtom(dateTimeFormatAtoms.timeZoneAtom);
+
+  return {
+    locale,
+    setLocale,
+    timeZone,
+    setTimeZone,
+  };
+}

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,11 +1,22 @@
-export function formatDateString(isoDateStr: string) {
-  const date = new Date(isoDateStr);
-
-  return date.toLocaleDateString();
+interface DateFormatOptionParams {
+  locale?: string;
+  timeZone?: string;
 }
 
-export function formatDateTimeString(isoDateStr: string) {
-  const date = new Date(isoDateStr);
+export function formatDateString(
+  dateStr: string,
+  options?: DateFormatOptionParams,
+) {
+  const date = new Date(dateStr);
 
-  return date.toLocaleString();
+  return date.toLocaleDateString(options?.locale, { timeZone: options?.timeZone });
+}
+
+export function formatDateTimeString(
+  dateStr: string,
+  options?: DateFormatOptionParams,
+) {
+  const date = new Date(dateStr);
+
+  return date.toLocaleString(options?.locale, { timeZone: options?.timeZone });
 }


### PR DESCRIPTION
## 개요

서버 시간대와 클라이언트 시간대가 다를 경우, Server Component와 Client Component 간 시간대 출력이 달라지는 문제를 해결하였습니다.

## 세부 구현 내용

https://github.com/HENOZIWD/opqo/blob/2b1379c1b116c905c78ed2f4736a8047b9e3c388/src/app/modules/components/DateTimeFormatProvider.tsx#L8-L40

https://github.com/HENOZIWD/opqo/blob/2b1379c1b116c905c78ed2f4736a8047b9e3c388/src/app/modules/utils/format.ts#L1-L7

`Intl.DateTimeFormat().reslovedOptions()`를 통해 클라이언트 측 시간대 및 언어 설정을 가져와 전역 상태로 관리합니다.

https://github.com/HENOZIWD/opqo/blob/2b1379c1b116c905c78ed2f4736a8047b9e3c388/src/components/common/date.tsx#L12-L43

`Date` 컴포넌트에서 초기 상태를 지정한 뒤 `useEffect`로 클라이언트 시간대 및 언어에 맞춰 업데이트되도록 하여 Server Component의 hydration 문제를 해결하였습니다.